### PR TITLE
Regenerate repository when creating a new project

### DIFF
--- a/create-project/action.yml
+++ b/create-project/action.yml
@@ -76,3 +76,11 @@ runs:
         --delete-after-days "$DELETE_AFTER_DAYS"                    \
         --description "$DESCRIPTION"                                \
         --instructions "$INSTRUCTIONS"
+
+  # Workaround: Backend process error: Giving up waiting for copr_base
+  # repository, please try to manually regenerate the DNF repository (e.g. by
+  # 'copr-cli regenerate-repos <project_name>')
+  - name: Regenerate repositories
+    shell: bash
+    run: |
+      copr-cli --config "$COPRCFG" regenerate-repos "$ACCOUNT/$PROJECT"


### PR DESCRIPTION
This is to workaround a known issue:
```
Backend process error: Giving up waiting for copr_base repository, please try to manually regenerate the DNF repository (e.g. by 'copr-cli regenerate-repos <project_name>')
```